### PR TITLE
change anticipate to choice for multiple choice picker

### DIFF
--- a/src/Console/Commands/LaravelRedisQueueClearCommand.php
+++ b/src/Console/Commands/LaravelRedisQueueClearCommand.php
@@ -18,7 +18,7 @@ class LaravelRedisQueueClearCommand extends Command
      */
     public function handle(RedisManager $redis)
     {
-        $queue = $this->anticipate('Queue name?', $this->getQueues());
+        $queue = $this->choice('Queue name?', $this->getQueues());
 
         $redis->del("queues:$queue");
     }


### PR DESCRIPTION
I think this small change makes `choice` a lot more convenient as it will print the list of available queues from which you can pick.. that's better than the autocomplete that the `anticipate` method provides